### PR TITLE
[T002] Create Storybook main configuration

### DIFF
--- a/front/.storybook/main.ts
+++ b/front/.storybook/main.ts
@@ -1,0 +1,28 @@
+import type { StorybookConfig } from '@storybook/vue3-vite';
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+
+  addons: [
+    '@storybook/addon-essentials',
+    '@storybook/addon-links',
+    '@storybook/addon-interactions',
+    '@storybook/addon-a11y',
+    '@storybook/addon-themes',
+  ],
+
+  framework: {
+    name: '@storybook/vue3-vite',
+    options: {},
+  },
+
+  docs: {
+    autodocs: 'tag',
+  },
+
+  typescript: {
+    check: true,
+  },
+};
+
+export default config;


### PR DESCRIPTION
 - Base: 001-setup-storybook-for
  - Compare: spec/001-setup-storybook-for/T002-create-main-config
  - Title: [T002] Create Storybook Main Configuration
  - Body:
  ## Summary
  - Created front/.storybook/main.ts with Storybook 8 configuration
  - Configured @storybook/vue3-vite framework integration
  - Added all required addons: essentials, links, interactions, a11y, themes
  - Set stories glob pattern for TypeScript files
  - Enabled autodocs with tag strategy

  ## Changes
  - New file: front/.storybook/main.ts

  ## Test Plan
  - [x] TypeScript configuration created
  - [x] All required addons configured
  - [x] Framework integration set to vue3-vite
  - [x] No TypeScript errors

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
