### PR TITLE
T005: Create typography reference tokens

### DIFF
--- a/front/src/designSystem/tokens/reference.tokens.ts
+++ b/front/src/designSystem/tokens/reference.tokens.ts
@@ -1,0 +1,90 @@
+/**
+ * Design System Reference Tokens
+ *
+ * Reference tokens are the foundational design values that define
+ * the visual language of the system. They are primitive values that
+ * are referenced by system tokens and component tokens.
+ *
+ * Architecture: Reference → System → Component
+ */
+
+/* ==========================================================================
+   TYPOGRAPHY
+   ========================================================================== */
+
+/**
+ * Font Family Tokens
+ *
+ * Primary font: Roboto (Google Fonts)
+ * Should be loaded via CDN in index.html or Storybook preview
+ */
+export const FONT_FAMILY = {
+  /** Primary font for body text, headings, and UI elements */
+  PRIMARY: "'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+  /** Monospace font for code blocks */
+  MONO: "'Roboto Mono', 'Courier New', monospace",
+} as const;
+
+/**
+ * Font Size Tokens (rem-based)
+ *
+ * Base size: 16px (1rem)
+ * Scale: Minor third (1.2 ratio)
+ */
+export const FONT_SIZE = {
+  XS: '0.75rem', // 12px - captions, labels
+  SM: '0.875rem', // 14px - small text, metadata
+  BASE: '1rem', // 16px - body text
+  MD: '1.125rem', // 18px - subheadings
+  LG: '1.25rem', // 20px - section headings
+  XL: '1.5rem', // 24px - page headings
+  '2XL': '1.875rem', // 30px - hero headings
+  '3XL': '2.25rem', // 36px - display headings
+  '4XL': '3rem', // 48px - large displays
+} as const;
+
+/**
+ * Font Weight Tokens
+ *
+ * Roboto supports: 100, 300, 400, 500, 700, 900
+ */
+export const FONT_WEIGHT = {
+  THIN: 100,
+  LIGHT: 300,
+  REGULAR: 400,
+  MEDIUM: 500,
+  BOLD: 700,
+  BLACK: 900,
+} as const;
+
+/**
+ * Line Height Tokens
+ *
+ * Optimized for readability across different text sizes
+ */
+export const LINE_HEIGHT = {
+  /** Tight line height for headings */
+  TIGHT: 1.25,
+  /** Normal line height for body text */
+  NORMAL: 1.5,
+  /** Relaxed line height for large text blocks */
+  RELAXED: 1.75,
+  /** Loose line height for enhanced readability */
+  LOOSE: 2,
+} as const;
+
+/**
+ * Letter Spacing Tokens (em-based)
+ *
+ * Subtle adjustments for different text sizes
+ */
+export const LETTER_SPACING = {
+  /** Tighter letter spacing for large headings */
+  TIGHT: '-0.025em',
+  /** Normal letter spacing */
+  NORMAL: '0em',
+  /** Wider letter spacing for small text */
+  WIDE: '0.025em',
+  /** Widest letter spacing for labels/buttons */
+  WIDER: '0.05em',
+} as const;

--- a/specs/002-design-system/tasks.md
+++ b/specs/002-design-system/tasks.md
@@ -27,7 +27,7 @@ This task breakdown implements a comprehensive design system foundation with 5 p
 
 **IMPORTANT**: All token definition tasks can run in parallel as they create separate files.
 
-- [ ] **T005 [P]** Create reference tokens file with typography primitives (font family, sizes, weights, line heights) in src/tokens/reference.tokens.ts
+- [x] **T005 [P]** Create reference tokens file with typography primitives (font family, sizes, weights, line heights) in src/tokens/reference.tokens.ts
 - [ ] **T006 [P]** Create reference tokens for spacing scale (rem-based, base-8 pattern) in src/tokens/reference.tokens.ts
 - [ ] **T007 [P]** Create reference tokens for shadows (5 levels: SM, BASE, MD, LG, XL) in src/tokens/reference.tokens.ts
 - [ ] **T008 [P]** Create reference tokens for border radius (7 values: NONE to FULL) in src/tokens/reference.tokens.ts


### PR DESCRIPTION
## Summary
- Created foundational typography design tokens in `reference.tokens.ts`
- Defined FONT_FAMILY tokens (Roboto primary, monospace fallback)
- Defined FONT_SIZE scale (XS to 4XL, rem-based with minor third ratio)
- Defined FONT_WEIGHT tokens (100-900 for Roboto weights)
- Defined LINE_HEIGHT tokens (TIGHT to LOOSE for readability)
- Defined LETTER_SPACING tokens (em-based subtle adjustments)

## Changes
- **front/src/designSystem/tokens/reference.tokens.ts**: Created with typography tokens
- **specs/002-design-system/tasks.md**: Marked T005 as completed

## Test Plan
- [x] TypeScript compiles without errors
- [x] Build succeeds (`npm run build`)
- [x] All tokens use const assertions for type safety
- [x] Documentation comments explain each token category

## Notes
- This is the first section of reference.tokens.ts
- Subsequent tasks (T006-T011) will add spacing, shadows, etc. to this file
- Roboto font should be loaded via Google Fonts CDN

🤖 Generated with [Claude Code](https://claude.com/claude-code)