### PR TITLE
T006: Add spacing scale reference tokens

### DIFF
--- a/front/src/designSystem/tokens/reference.tokens.ts
+++ b/front/src/designSystem/tokens/reference.tokens.ts
@@ -88,3 +88,54 @@ export const LETTER_SPACING = {
   /** Widest letter spacing for labels/buttons */
   WIDER: '0.05em',
 } as const;
+
+/* ==========================================================================
+   SPACING
+   ========================================================================== */
+
+/**
+ * Spacing Scale Tokens (rem-based, base-8 pattern)
+ *
+ * Base unit: 0.5rem (8px)
+ * Scale follows 8-point grid system for consistent spacing
+ * and alignment across the design system.
+ *
+ * Usage:
+ * - Use smaller values (0.5-2) for tight spacing (padding, gaps)
+ * - Use medium values (3-8) for component spacing
+ * - Use larger values (10-20) for layout spacing
+ */
+export const SPACING = {
+  /** 0px - No spacing */
+  NONE: '0',
+  /** 4px - Extra tight spacing */
+  '0_5': '0.25rem',
+  /** 8px - Base unit, tight spacing */
+  '1': '0.5rem',
+  /** 12px - Small spacing */
+  '1_5': '0.75rem',
+  /** 16px - Default spacing */
+  '2': '1rem',
+  /** 20px - Comfortable spacing */
+  '2_5': '1.25rem',
+  /** 24px - Medium spacing */
+  '3': '1.5rem',
+  /** 32px - Large spacing */
+  '4': '2rem',
+  /** 40px - Extra large spacing */
+  '5': '2.5rem',
+  /** 48px - Section spacing */
+  '6': '3rem',
+  /** 56px - Large section spacing */
+  '7': '3.5rem',
+  /** 64px - Extra large section */
+  '8': '4rem',
+  /** 80px - Layout spacing */
+  '10': '5rem',
+  /** 96px - Large layout spacing */
+  '12': '6rem',
+  /** 128px - Extra large layout */
+  '16': '8rem',
+  /** 160px - Hero section spacing */
+  '20': '10rem',
+} as const;

--- a/specs/002-design-system/tasks.md
+++ b/specs/002-design-system/tasks.md
@@ -28,7 +28,7 @@ This task breakdown implements a comprehensive design system foundation with 5 p
 **IMPORTANT**: All token definition tasks can run in parallel as they create separate files.
 
 - [x] **T005 [P]** Create reference tokens file with typography primitives (font family, sizes, weights, line heights) in src/tokens/reference.tokens.ts
-- [ ] **T006 [P]** Create reference tokens for spacing scale (rem-based, base-8 pattern) in src/tokens/reference.tokens.ts
+- [x] **T006 [P]** Create reference tokens for spacing scale (rem-based, base-8 pattern) in src/tokens/reference.tokens.ts
 - [ ] **T007 [P]** Create reference tokens for shadows (5 levels: SM, BASE, MD, LG, XL) in src/tokens/reference.tokens.ts
 - [ ] **T008 [P]** Create reference tokens for border radius (7 values: NONE to FULL) in src/tokens/reference.tokens.ts
 - [ ] **T009 [P]** Create reference tokens for z-index scale (8 levels: HIDE to TOOLTIP) in src/tokens/reference.tokens.ts


### PR DESCRIPTION
## Summary
- Added SPACING tokens following 8-point grid system
- Base unit: 0.5rem (8px) for consistent alignment
- 16 spacing values from NONE (0px) to 20 (160px)
- Organized by use case: tight, component, and layout spacing
- Uses rem units for responsive scaling

## Changes
- **front/src/designSystem/tokens/reference.tokens.ts**: Added SPACING section
- **specs/002-design-system/tasks.md**: Marked T006 as completed

## Test Plan
- [x] TypeScript compiles without errors
- [x] Build succeeds (`npm run build`)
- [x] All tokens use const assertions
- [x] Comprehensive documentation for usage guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)