### PR TITLE
T008: Add border radius reference tokens

### DIFF
--- a/front/src/designSystem/tokens/reference.tokens.ts
+++ b/front/src/designSystem/tokens/reference.tokens.ts
@@ -173,3 +173,40 @@ export const SHADOW = {
   /** Inner shadow - Inset elements */
   INNER: 'inset 0 2px 4px 0 rgba(0, 0, 0, 0.05)',
 } as const;
+
+/* ==========================================================================
+   BORDER RADIUS
+   ========================================================================== */
+
+/**
+ * Border Radius Tokens (7 values: NONE to FULL)
+ *
+ * Progressive rounding scale for UI elements.
+ * Defines corner roundness from sharp edges to fully circular.
+ *
+ * Usage:
+ * - NONE: Sharp corners (tables, dividers)
+ * - SM: Subtle rounding (inputs, small buttons)
+ * - BASE: Default rounding (buttons, cards)
+ * - MD/LG: Pronounced rounding (large cards, containers)
+ * - XL/2XL: Heavy rounding (badges, pills)
+ * - FULL: Circular elements (avatars, icon buttons)
+ */
+export const BORDER_RADIUS = {
+  /** 0px - No rounding, sharp corners */
+  NONE: '0',
+  /** 2px - Subtle rounding */
+  SM: '0.125rem',
+  /** 4px - Default rounding */
+  BASE: '0.25rem',
+  /** 6px - Medium rounding */
+  MD: '0.375rem',
+  /** 8px - Large rounding */
+  LG: '0.5rem',
+  /** 12px - Extra large rounding */
+  XL: '0.75rem',
+  /** 16px - 2X large rounding */
+  '2XL': '1rem',
+  /** 9999px - Fully circular/pill shape */
+  FULL: '9999px',
+} as const;

--- a/specs/002-design-system/tasks.md
+++ b/specs/002-design-system/tasks.md
@@ -30,7 +30,7 @@ This task breakdown implements a comprehensive design system foundation with 5 p
 - [x] **T005 [P]** Create reference tokens file with typography primitives (font family, sizes, weights, line heights) in src/tokens/reference.tokens.ts
 - [x] **T006 [P]** Create reference tokens for spacing scale (rem-based, base-8 pattern) in src/tokens/reference.tokens.ts
 - [x] **T007 [P]** Create reference tokens for shadows (5 levels: SM, BASE, MD, LG, XL) in src/tokens/reference.tokens.ts
-- [ ] **T008 [P]** Create reference tokens for border radius (7 values: NONE to FULL) in src/tokens/reference.tokens.ts
+- [x] **T008 [P]** Create reference tokens for border radius (7 values: NONE to FULL) in src/tokens/reference.tokens.ts
 - [ ] **T009 [P]** Create reference tokens for z-index scale (8 levels: HIDE to TOOLTIP) in src/tokens/reference.tokens.ts
 - [ ] **T010 [P]** Create reference tokens for opacity values (8 steps: 0 to 100) in src/tokens/reference.tokens.ts
 - [ ] **T011 [P]** Create reference tokens for transitions (duration + timing functions) in src/tokens/reference.tokens.ts


### PR DESCRIPTION
## Summary
- Added BORDER_RADIUS tokens with 8 values (NONE to FULL)
- Progressive rounding scale from sharp corners to fully circular
- Range: 0px (NONE) to 9999px (FULL)
- Comprehensive documentation for each value's use case

## Changes
- **front/src/designSystem/tokens/reference.tokens.ts**: Added BORDER_RADIUS section
- **specs/002-design-system/tasks.md**: Marked T008 as completed

## Test Plan
- [x] TypeScript compiles without errors
- [x] Build succeeds (`npm run build`)
- [x] All tokens use const assertions
- [x] Usage guidance provided for each level

🤖 Generated with [Claude Code](https://claude.com/claude-code)