### PR TITLE
T009: Add z-index scale reference tokens

### DIFF
--- a/front/src/designSystem/tokens/reference.tokens.ts
+++ b/front/src/designSystem/tokens/reference.tokens.ts
@@ -210,3 +210,45 @@ export const BORDER_RADIUS = {
   /** 9999px - Fully circular/pill shape */
   FULL: '9999px',
 } as const;
+
+/* ==========================================================================
+   Z-INDEX
+   ========================================================================== */
+
+/**
+ * Z-Index Scale Tokens (8 levels: HIDE to TOOLTIP)
+ *
+ * Stacking order system for layered UI elements.
+ * Prevents z-index conflicts with predefined scale.
+ *
+ * Usage:
+ * - HIDE: Hidden elements (negative z-index)
+ * - BASE: Default layer (0)
+ * - DROPDOWN: Dropdowns, menus
+ * - STICKY: Sticky headers, footers
+ * - FIXED: Fixed position elements
+ * - MODAL_BACKDROP: Modal overlays
+ * - MODAL: Modal dialogs
+ * - POPOVER: Popovers, tooltips
+ * - TOOLTIP: Highest priority (tooltips)
+ */
+export const Z_INDEX = {
+  /** -1 - Hidden elements */
+  HIDE: -1,
+  /** 0 - Base layer */
+  BASE: 0,
+  /** 10 - Dropdown menus */
+  DROPDOWN: 10,
+  /** 20 - Sticky elements */
+  STICKY: 20,
+  /** 30 - Fixed position elements */
+  FIXED: 30,
+  /** 40 - Modal backdrop overlays */
+  MODAL_BACKDROP: 40,
+  /** 50 - Modal dialogs */
+  MODAL: 50,
+  /** 60 - Popovers */
+  POPOVER: 60,
+  /** 70 - Tooltips (highest priority) */
+  TOOLTIP: 70,
+} as const;

--- a/specs/002-design-system/tasks.md
+++ b/specs/002-design-system/tasks.md
@@ -31,7 +31,7 @@ This task breakdown implements a comprehensive design system foundation with 5 p
 - [x] **T006 [P]** Create reference tokens for spacing scale (rem-based, base-8 pattern) in src/tokens/reference.tokens.ts
 - [x] **T007 [P]** Create reference tokens for shadows (5 levels: SM, BASE, MD, LG, XL) in src/tokens/reference.tokens.ts
 - [x] **T008 [P]** Create reference tokens for border radius (7 values: NONE to FULL) in src/tokens/reference.tokens.ts
-- [ ] **T009 [P]** Create reference tokens for z-index scale (8 levels: HIDE to TOOLTIP) in src/tokens/reference.tokens.ts
+- [x] **T009 [P]** Create reference tokens for z-index scale (8 levels: HIDE to TOOLTIP) in src/tokens/reference.tokens.ts
 - [ ] **T010 [P]** Create reference tokens for opacity values (8 steps: 0 to 100) in src/tokens/reference.tokens.ts
 - [ ] **T011 [P]** Create reference tokens for transitions (duration + timing functions) in src/tokens/reference.tokens.ts
 


### PR DESCRIPTION
## Summary
- Added Z_INDEX tokens with 9 levels (HIDE to TOOLTIP)
- Prevents z-index conflicts with predefined stacking order
- Range: -1 (HIDE) to 70 (TOOLTIP)
- Clear hierarchy for layered UI elements

## Changes
- **front/src/designSystem/tokens/reference.tokens.ts**: Added Z_INDEX section
- **specs/002-design-system/tasks.md**: Marked T009 as completed

## Test Plan
- [x] TypeScript compiles without errors
- [x] Build succeeds (`npm run build`)
- [x] All tokens use const assertions
- [x] Documentation explains stacking order hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)