### PR TITLE
T010: Add opacity reference tokens

### DIFF
--- a/front/src/designSystem/tokens/reference.tokens.ts
+++ b/front/src/designSystem/tokens/reference.tokens.ts
@@ -252,3 +252,45 @@ export const Z_INDEX = {
   /** 70 - Tooltips (highest priority) */
   TOOLTIP: 70,
 } as const;
+
+/* ==========================================================================
+   OPACITY
+   ========================================================================== */
+
+/**
+ * Opacity Tokens (8 steps: 0 to 100)
+ *
+ * Transparency scale for fading, disabled states, and overlays.
+ * Uses percentage-based values for clarity.
+ *
+ * Usage:
+ * - 0: Completely transparent
+ * - 5/10: Very subtle transparency (hover effects)
+ * - 20/30: Disabled states, subtle overlays
+ * - 50: Semi-transparent overlays
+ * - 60/75: Prominent but translucent
+ * - 90: Almost opaque
+ * - 100: Fully opaque
+ */
+export const OPACITY = {
+  /** 0% - Completely transparent */
+  '0': '0',
+  /** 5% - Very subtle transparency */
+  '5': '0.05',
+  /** 10% - Subtle transparency */
+  '10': '0.1',
+  /** 20% - Light transparency */
+  '20': '0.2',
+  /** 30% - Disabled states */
+  '30': '0.3',
+  /** 50% - Semi-transparent */
+  '50': '0.5',
+  /** 60% - Prominent transparency */
+  '60': '0.6',
+  /** 75% - Mostly opaque */
+  '75': '0.75',
+  /** 90% - Almost fully opaque */
+  '90': '0.9',
+  /** 100% - Fully opaque */
+  '100': '1',
+} as const;

--- a/specs/002-design-system/tasks.md
+++ b/specs/002-design-system/tasks.md
@@ -32,7 +32,7 @@ This task breakdown implements a comprehensive design system foundation with 5 p
 - [x] **T007 [P]** Create reference tokens for shadows (5 levels: SM, BASE, MD, LG, XL) in src/tokens/reference.tokens.ts
 - [x] **T008 [P]** Create reference tokens for border radius (7 values: NONE to FULL) in src/tokens/reference.tokens.ts
 - [x] **T009 [P]** Create reference tokens for z-index scale (8 levels: HIDE to TOOLTIP) in src/tokens/reference.tokens.ts
-- [ ] **T010 [P]** Create reference tokens for opacity values (8 steps: 0 to 100) in src/tokens/reference.tokens.ts
+- [x] **T010 [P]** Create reference tokens for opacity values (8 steps: 0 to 100) in src/tokens/reference.tokens.ts
 - [ ] **T011 [P]** Create reference tokens for transitions (duration + timing functions) in src/tokens/reference.tokens.ts
 
 ## Phase 3.3: Color Palettes (Parallel Execution)


### PR DESCRIPTION
## Summary
- Added OPACITY tokens with 10 levels (0 to 100)
- Transparency scale for fading effects, disabled states, and overlays
- Range: 0 (transparent) to 1 (opaque)
- Decimal values for precise opacity control

## Changes
- **front/src/designSystem/tokens/reference.tokens.ts**: Added OPACITY section
- **specs/002-design-system/tasks.md**: Marked T010 as completed

## Test Plan
- [x] TypeScript compiles without errors
- [x] Build succeeds (`npm run build`)
- [x] All tokens use const assertions
- [x] Documentation describes common use cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)