### PR TITLE
feat(T009): Minimalist palette (gray) - Final palette

### DIFF
--- a/front/src/designSystem/styles/tokens.css
+++ b/front/src/designSystem/styles/tokens.css
@@ -714,3 +714,149 @@
   --color-border-strong: var(--color-neutral-300);
   --color-border-focus: var(--color-primary-400);
 }
+
+/* ==========================================================================
+   MINIMALIST PALETTE (GRAY)
+   Light Mode - Clean, modern, minimalist
+   ========================================================================== */
+
+.minimalist.light {
+  /* Primary Colors - Slate/Gray Scale (monochromatic) */
+  --color-primary-50: #F8FAFC;
+  --color-primary-100: #F1F5F9;
+  --color-primary-200: #E2E8F0;
+  --color-primary-300: #CBD5E1;
+  --color-primary-400: #94A3B8;
+  --color-primary-500: #64748B;
+  --color-primary-600: #475569;
+  --color-primary-700: #334155;
+  --color-primary-800: #1E293B;
+  --color-primary-900: #0F172A;
+
+  /* Neutral Colors - Shared Scale (same as primary for monochromatic effect) */
+  --color-neutral-0: #FFFFFF;
+  --color-neutral-50: #F8FAFC;
+  --color-neutral-100: #F1F5F9;
+  --color-neutral-200: #E2E8F0;
+  --color-neutral-300: #CBD5E1;
+  --color-neutral-400: #94A3B8;
+  --color-neutral-500: #64748B;
+  --color-neutral-600: #475569;
+  --color-neutral-700: #334155;
+  --color-neutral-800: #1E293B;
+  --color-neutral-900: #0F172A;
+
+  /* Semantic Colors */
+  --color-success-50: #ECFDF5;
+  --color-success-100: #D1FAE5;
+  --color-success-500: #10B981;
+  --color-success-700: #047857;
+
+  --color-warning-50: #FFFBEB;
+  --color-warning-100: #FEF3C7;
+  --color-warning-500: #F59E0B;
+  --color-warning-700: #B45309;
+
+  --color-error-50: #FEF2F2;
+  --color-error-100: #FEE2E2;
+  --color-error-500: #EF4444;
+  --color-error-700: #B91C1C;
+
+  --color-info-50: #EFF6FF;
+  --color-info-100: #DBEAFE;
+  --color-info-500: #3B82F6;
+  --color-info-700: #1D4ED8;
+
+  /* System Tokens - Light Mode */
+  --color-background-default: var(--color-neutral-0);
+  --color-background-subtle: var(--color-neutral-50);
+  --color-background-muted: var(--color-neutral-100);
+
+  --color-surface-default: var(--color-neutral-0);
+  --color-surface-raised: var(--color-neutral-50);
+  --color-surface-overlay: var(--color-neutral-100);
+
+  --color-text-primary: var(--color-neutral-900);
+  --color-text-secondary: var(--color-neutral-700);
+  --color-text-tertiary: var(--color-neutral-600);
+  --color-text-disabled: var(--color-neutral-400);
+  --color-text-inverse: var(--color-neutral-0);
+
+  --color-border-default: var(--color-neutral-200);
+  --color-border-subtle: var(--color-neutral-100);
+  --color-border-strong: var(--color-neutral-300);
+  --color-border-focus: var(--color-primary-500);
+}
+
+/* ==========================================================================
+   MINIMALIST PALETTE (GRAY)
+   Dark Mode - Modern, sophisticated, minimal
+   ========================================================================== */
+
+.minimalist.dark {
+  /* Primary Colors - Slate/Gray Scale (Inverted for Dark Mode) */
+  --color-primary-50: #0F172A;
+  --color-primary-100: #1E293B;
+  --color-primary-200: #334155;
+  --color-primary-300: #475569;
+  --color-primary-400: #64748B;
+  --color-primary-500: #94A3B8;
+  --color-primary-600: #CBD5E1;
+  --color-primary-700: #E2E8F0;
+  --color-primary-800: #F1F5F9;
+  --color-primary-900: #F8FAFC;
+
+  /* Neutral Colors - Inverted for Dark Mode */
+  --color-neutral-0: #0F172A;
+  --color-neutral-50: #1E293B;
+  --color-neutral-100: #334155;
+  --color-neutral-200: #475569;
+  --color-neutral-300: #64748B;
+  --color-neutral-400: #94A3B8;
+  --color-neutral-500: #CBD5E1;
+  --color-neutral-600: #E2E8F0;
+  --color-neutral-700: #F1F5F9;
+  --color-neutral-800: #F8FAFC;
+  --color-neutral-900: #FFFFFF;
+
+  /* Semantic Colors - Optimized for Dark Background */
+  --color-success-50: #064E3B;
+  --color-success-100: #065F46;
+  --color-success-500: #34D399;
+  --color-success-700: #A7F3D0;
+
+  --color-warning-50: #78350F;
+  --color-warning-100: #92400E;
+  --color-warning-500: #FBBF24;
+  --color-warning-700: #FDE68A;
+
+  --color-error-50: #7F1D1D;
+  --color-error-100: #991B1B;
+  --color-error-500: #F87171;
+  --color-error-700: #FECACA;
+
+  --color-info-50: #1E3A8A;
+  --color-info-100: #1E40AF;
+  --color-info-500: #60A5FA;
+  --color-info-700: #BFDBFE;
+
+  /* System Tokens - Dark Mode */
+  --color-background-default: var(--color-neutral-0);
+  --color-background-subtle: var(--color-neutral-50);
+  --color-background-muted: var(--color-neutral-100);
+
+  --color-surface-default: var(--color-neutral-50);
+  --color-surface-raised: var(--color-neutral-100);
+  --color-surface-overlay: var(--color-neutral-200);
+
+  --color-text-primary: var(--color-neutral-900);
+  --color-text-secondary: var(--color-neutral-700);
+  --color-text-tertiary: var(--color-neutral-600);
+  --color-text-disabled: var(--color-neutral-400);
+  --color-text-inverse: var(--color-neutral-0);
+
+  --color-border-default: var(--color-neutral-200);
+  --color-border-subtle: var(--color-neutral-100);
+  --color-border-strong: var(--color-neutral-300);
+  --color-border-focus: var(--color-primary-400);
+}


### PR DESCRIPTION
## Summary
Added Minimalist palette (slate/gray) with light and dark modes - completes all palette implementations.

## Changes

### Palette Implementation
- Added `.minimalist.light` with monochromatic slate/gray primary colors (#64748B base)
- Added `.minimalist.dark` with inverted slate scale
- Each mode defines 52 tokens (10 primary, 11 neutral, 12 semantic, 19 system)
- **Unique Feature**: Primary and neutral colors both use slate scale for pure monochromatic aesthetic

### Palette Purpose
- **Theme**: Clean, modern, minimalist
- **Use Cases**: Portfolios, blogs, content-focused sites
- **Color Family**: Slate/Gray (Tailwind slate scale)
- **Design Philosophy**: Monochromatic simplicity - primary colors are gray-based

## Milestone
**All 4 new palettes complete:**
- ✅ T006: Creative Energy (purple)
- ✅ T007: Natural Harmony (green)
- ✅ T008: Warm Welcome (orange)
- ✅ T009: Minimalist (gray)

**Total**: 10 variations (5 palettes × 2 modes)

## Next Steps
- T010-T011: Storybook integration
- T012-T014: Documentation

## Related
- Task: T009 from specs/003-palette-switcher/tasks.md
- Depends on: T008 (Warm Welcome palette)
- Blocks: T010 (Storybook configuration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)