### PR TITLE
feat(T010): Storybook globalTypes for palette/mode controls

### DIFF
--- a/front/.storybook/preview.ts
+++ b/front/.storybook/preview.ts
@@ -3,7 +3,46 @@ import '../src/style.css';
 import type { Preview } from '@storybook/vue3';
 import { withThemeByClassName } from '@storybook/addon-themes';
 
+/**
+ * Global toolbar controls for palette and mode switching
+ * Allows preview of components in all 10 palette variations (5 palettes × 2 modes)
+ */
+export const globalTypes = {
+  palette: {
+    name: 'Palette',
+    description: 'Color palette',
+    defaultValue: 'corporate-trust',
+    toolbar: {
+      icon: 'paintbrush',
+      items: [
+        { value: 'corporate-trust', title: 'Corporate Trust (Blue)' },
+        { value: 'creative-energy', title: 'Creative Energy (Purple)' },
+        { value: 'natural-harmony', title: 'Natural Harmony (Green)' },
+        { value: 'warm-welcome', title: 'Warm Welcome (Orange)' },
+        { value: 'minimalist', title: 'Minimalist (Gray)' },
+      ],
+      showName: true,
+      dynamicTitle: true,
+    },
+  },
+  mode: {
+    name: 'Mode',
+    description: 'Light or dark mode',
+    defaultValue: 'light',
+    toolbar: {
+      icon: 'circlehollow',
+      items: [
+        { value: 'light', title: 'Light', icon: 'sun' },
+        { value: 'dark', title: 'Dark', icon: 'moon' },
+      ],
+      showName: true,
+      dynamicTitle: true,
+    },
+  },
+};
+
 const preview: Preview = {
+  globalTypes,
   parameters: {
     actions: {
       argTypesRegex: '^on[A-Z].*',


### PR DESCRIPTION
## Summary
Added Storybook globalTypes configuration for palette and mode toolbar controls.

## Changes

### Storybook Configuration
- Added `globalTypes` object to `.storybook/preview.ts`
- **Palette dropdown**: 5 options with paintbrush icon
  - Corporate Trust (Blue)
  - Creative Energy (Purple)
  - Natural Harmony (Green)
  - Warm Welcome (Orange)
  - Minimalist (Gray)
- **Mode toggle**: 2 options with sun/moon icons
  - Light (default)
  - Dark
- Dynamic titles enabled for both controls
- Default values: `corporate-trust`, `light`

### Integration Points
- Values accessible via `context.globals.palette` and `context.globals.mode`
- All stories automatically inherit these toolbar controls
- Exported globalTypes for use in custom decorators (T011)

### User Experience
- Two toolbar controls appear at top of Storybook UI
- Palette dropdown shows all 5 color schemes
- Mode toggle switches between light/dark themes
- Enables preview of all 10 palette variations (5 palettes × 2 modes)

## Testing
Manual testing in Storybook:
1. Start Storybook: `npm run storybook`
2. Open any story
3. Verify palette dropdown in toolbar with 5 options
4. Verify mode toggle in toolbar with light/dark
5. Verify icons display correctly (paintbrush, sun, moon)
6. Verify default values: corporate-trust, light

## Next Steps
- T011: Create custom `withTheme` decorator to apply CSS classes based on globalTypes values
- T012-T014: Documentation and examples

## Related
- Task: T010 from specs/003-palette-switcher/tasks.md
- Depends on: T006-T009 (palette definitions)
- Blocks: T011 (withTheme decorator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)